### PR TITLE
Issue 67 - Providing basic client sided routing support

### DIFF
--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -2,7 +2,7 @@
   import { getContext, createEventDispatcher } from "svelte";
   import { ROUTER, LOCATION } from "./contexts.js";
   import { navigate } from "./history.js";
-  import { startsWith, resolve, shouldNavigate, getLocation } from "./utils.js";
+  import { startsWith, resolve, shouldNavigate, getPath } from "./utils.js";
 
   export let to = "#";
   export let replace = false;
@@ -15,8 +15,8 @@
 
   let href, isPartiallyCurrent, isCurrent, props;
   $: href = to === "/" ? $base.uri : resolve(to, $base.uri);
-  $: isPartiallyCurrent = startsWith(getLocation($location, $base.hash), href);
-  $: isCurrent = href === getLocation($location, hash);
+  $: isPartiallyCurrent = startsWith(getPath($location, $base.hash), href);
+  $: isCurrent = href === getPath($location, hash);
   $: ariaCurrent = isCurrent ? "page" : undefined;
   $: props = getProps({
     location: $location,
@@ -32,7 +32,7 @@
       event.preventDefault();
       // Don't push another entry to the history stack when the user
       // clicks on a Link to the page they are currently on.
-      const shouldReplace = getLocation($location, hash) === href || replace;
+      const shouldReplace = getPath($location, hash) === href || replace;
       navigate(href, { state, replace: shouldReplace });
     }
   }

--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -16,7 +16,7 @@
   let href, isPartiallyCurrent, isCurrent, props;
   $: href = to === "/" ? $base.uri : resolve(to, $base.uri);
   $: isPartiallyCurrent = startsWith(getPath($location, $base.hash), href);
-  $: isCurrent = href === getPath($location, hash);
+  $: isCurrent = href === getPath($location, $base.hash);
   $: ariaCurrent = isCurrent ? "page" : undefined;
   $: props = getProps({
     location: $location,
@@ -32,7 +32,7 @@
       event.preventDefault();
       // Don't push another entry to the history stack when the user
       // clicks on a Link to the page they are currently on.
-      const shouldReplace = getPath($location, hash) === href || replace;
+      const shouldReplace = getPath($location, $base.hash) === href || replace;
       navigate(href, { state, replace: shouldReplace });
     }
   }

--- a/src/Link.svelte
+++ b/src/Link.svelte
@@ -2,7 +2,7 @@
   import { getContext, createEventDispatcher } from "svelte";
   import { ROUTER, LOCATION } from "./contexts.js";
   import { navigate } from "./history.js";
-  import { startsWith, resolve, shouldNavigate } from "./utils.js";
+  import { startsWith, resolve, shouldNavigate, getLocation } from "./utils.js";
 
   export let to = "#";
   export let replace = false;
@@ -15,8 +15,8 @@
 
   let href, isPartiallyCurrent, isCurrent, props;
   $: href = to === "/" ? $base.uri : resolve(to, $base.uri);
-  $: isPartiallyCurrent = startsWith($location.pathname, href);
-  $: isCurrent = href === $location.pathname;
+  $: isPartiallyCurrent = startsWith(getLocation($location, $base.hash), href);
+  $: isCurrent = href === getLocation($location, hash);
   $: ariaCurrent = isCurrent ? "page" : undefined;
   $: props = getProps({
     location: $location,
@@ -32,7 +32,7 @@
       event.preventDefault();
       // Don't push another entry to the history stack when the user
       // clicks on a Link to the page they are currently on.
-      const shouldReplace = $location.pathname === href || replace;
+      const shouldReplace = getLocation($location, hash) === href || replace;
       navigate(href, { state, replace: shouldReplace });
     }
   }

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -31,7 +31,7 @@
     : writable({
         path: basepath,
         uri: basepath,
-        hash: hash
+        hash
       });
 
   const routerBase = derived([base, activeRoute], ([base, activeRoute]) => {

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -3,7 +3,7 @@
   import { writable, derived } from "svelte/store";
   import { LOCATION, ROUTER } from "./contexts.js";
   import { globalHistory } from "./history.js";
-  import { pick, match, stripSlashes, combinePaths, getLocation } from "./utils.js";
+  import { pick, match, stripSlashes, combinePaths, getPath } from "./utils.js";
 
   export let basepath = "/";
   export let url = null;
@@ -67,7 +67,7 @@
         return;
       }
 
-      const matchingRoute = match(route, getLocation($location, hash));
+      const matchingRoute = match(route, getPath($location, hash));
       if (matchingRoute) {
         activeRoute.set(matchingRoute);
         hasActiveRoute = true;
@@ -102,7 +102,7 @@
   // will not find an active Route in SSR and in the browser it will only
   // pick an active Route after all Routes have been registered.
   $: {
-    const bestMatch = pick($routes, getLocation($location, hash));
+    const bestMatch = pick($routes, getPath($location, hash));
     activeRoute.set(bestMatch);
   }
 

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -7,6 +7,7 @@
 
   export let basepath = "/";
   export let url = null;
+  export let hash = false;
 
   const locationContext = getContext(LOCATION);
   const routerContext = getContext(ROUTER);
@@ -100,7 +101,7 @@
   // will not find an active Route in SSR and in the browser it will only
   // pick an active Route after all Routes have been registered.
   $: {
-    const bestMatch = pick($routes, $location.pathname);
+    const bestMatch = pick($routes, hash ? $location.hash : $location.pathname);
     activeRoute.set(bestMatch);
   }
 

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -66,7 +66,7 @@
         return;
       }
 
-      const matchingRoute = match(route, $location.pathname);
+      const matchingRoute = match(route, hash ? $location.hash : $location.pathname);
       if (matchingRoute) {
         activeRoute.set(matchingRoute);
         hasActiveRoute = true;

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -3,7 +3,7 @@
   import { writable, derived } from "svelte/store";
   import { LOCATION, ROUTER } from "./contexts.js";
   import { globalHistory } from "./history.js";
-  import { pick, match, stripSlashes, combinePaths } from "./utils.js";
+  import { pick, match, stripSlashes, combinePaths, getLocation } from "./utils.js";
 
   export let basepath = "/";
   export let url = null;
@@ -30,7 +30,8 @@
     ? routerContext.routerBase
     : writable({
         path: basepath,
-        uri: basepath
+        uri: basepath,
+        hash: hash
       });
 
   const routerBase = derived([base, activeRoute], ([base, activeRoute]) => {
@@ -66,7 +67,7 @@
         return;
       }
 
-      const matchingRoute = match(route, hash ? $location.hash : $location.pathname);
+      const matchingRoute = match(route, getLocation($location, hash));
       if (matchingRoute) {
         activeRoute.set(matchingRoute);
         hasActiveRoute = true;
@@ -101,7 +102,7 @@
   // will not find an active Route in SSR and in the browser it will only
   // pick an active Route after all Routes have been registered.
   $: {
-    const bestMatch = pick($routes, hash ? $location.hash : $location.pathname);
+    const bestMatch = pick($routes, getLocation($location, hash));
     activeRoute.set(bestMatch);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -330,4 +330,13 @@ function shouldNavigate(event) {
   );
 }
 
+/**
+ * Determines location base on hash settings
+ * @param {*} $location - Location reference.
+ * @param {*} usingHash - Dictates whether or not client is using hash routing. 
+ */
+function getLocation(location, usingHash = false) {
+  return usingHash ? location.hash : location.pathname; 
+}
+
 export { stripSlashes, pick, match, resolve, combinePaths, shouldNavigate };

--- a/src/utils.js
+++ b/src/utils.js
@@ -331,12 +331,12 @@ function shouldNavigate(event) {
 }
 
 /**
- * Determines location base on hash settings
- * @param {*} $location - Location reference.
+ * Determines location path base on hash settings
+ * @param {*} location - Location reference.
  * @param {*} usingHash - Dictates whether or not client is using hash routing. 
  */
-function getLocation(location, usingHash = false) {
+function getPath(location, usingHash = false) {
   return usingHash ? location.hash : location.pathname; 
 }
 
-export { stripSlashes, pick, match, resolve, combinePaths, shouldNavigate };
+export { stripSlashes, pick, match, resolve, combinePaths, shouldNavigate, getPath };


### PR DESCRIPTION
Related issue: [Issue 67](https://github.com/EmilTholin/svelte-routing/issues/67)

Simple changes to add client sided support w/ hash bangs.

Example use:

```html
<script>
  import Home from './Home.svelte'
  import MyComponent from './Component.svelte'

  let url = ""
  let basepath = "#"
  let hash = true
</script>

<Router url="{url}" basepath="{basepath}" hash="{hash}">
  <Route path="someRoute" component="{MyComponent}" />
  <Route path="/">
    <Home />
  </Route>
  <Link to="someRoute">Some Page</Link>
</Router>
```

---

Maintaining my own fork, due to constraints with the svelte-routing dev team client sided support will not be featured or maintained.